### PR TITLE
Remove this warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
File encoding has not been set, using platform
encoding UTF-8, i.e. build is platform dependent!